### PR TITLE
chore: use localEnvFile from node:process rather than dotenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A tool for generating retrospectives for GitHub activity.
 
 ### Contributing and Development.
 
-To contribute, you'll need to get a GitHub Personal Access Token and add it to a `.env` file in eacch workspace that you're going to work in. `dotenv` doesn't currently support workspaces, so you'll need to do work from each workspace rather than from the root of the project.
+To contribute, you'll need to get a GitHub Personal Access Token and add it to a `.env` file in eacch workspace that you're going to work in. We're using [Node.js's `localEnvFile` feature](https://nodejs.org/api/process.html#processloadenvfilepath).
 
 ### Scripts
 

--- a/core/index.js
+++ b/core/index.js
@@ -1,7 +1,9 @@
-require('dotenv').config()
+const { loadEnvFile } = require('node:process');
 let { graphql } = require('@octokit/graphql')
 const query = require('./queries/query')
 const returnUsable = require('./util/returnUsable')
+
+loadEnvFile()
 
 graphql = graphql.defaults({
   headers: {

--- a/core/package.json
+++ b/core/package.json
@@ -25,7 +25,6 @@
     "standard": "^16.0.4"
   },
   "dependencies": {
-    "dotenv": "^16.0.0",
     "@octokit/rest": "^18.12.0",
     "luxon": "^2.3.1"
   },

--- a/generate/package.json
+++ b/generate/package.json
@@ -23,7 +23,6 @@
     "@retrogen/templates": "^0.0.2"
   },
   "devDependencies": {
-    "dotenv": "^16.0.0",
     "luxon": "^2.3.1",
     "mocha": "^9.2.2",
     "nyc": "^15.1.0",

--- a/templates/package.json
+++ b/templates/package.json
@@ -23,7 +23,6 @@
   "license": "MIT",
   "devDependencies": {
     "@retrogen/core": "^0.0.2",
-    "dotenv": "^16.4.5",
     "luxon": "^3.4.4"
   },
   "repository": {


### PR DESCRIPTION
Switch to using Node.js's built-in `.env` feature rather than using `dotenv`.