### PR TITLE
chore: remove mocha

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "lint": "standard",
     "lint:fix": "standard --fix",
-    "test": "mocha",
-    "coverage": "nyc mocha",
+    "test": "node --test",
+    "coverage": "nyc node --test",
     "examples": "npm run examples:default && npm run examples:defaultWithOptions && npm run examples:relativeDate",
     "examples:output": "npm run examples:default:output && npm run examples:defaultWithOptions:output && npm run examples:relativeDate:output",
     "examples:default": "node examples/default.js",
@@ -20,7 +20,6 @@
   "author": "Tierney Cyren <hello@bnb.im> (https://bnb.im/)",
   "license": "MIT",
   "devDependencies": {
-    "mocha": "^9.2.2",
     "nyc": "^15.1.0",
     "standard": "^16.0.4"
   },

--- a/generate/package.json
+++ b/generate/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "lint": "standard",
     "lint:fix": "standard --fix",
-    "test": "mocha",
-    "coverage": "nyc mocha",
+    "test": "node --test",
+    "coverage": "nyc node --test",
     "examples": "npm run examples:default && npm run examples:dynamicDates",
     "examples:output": "npm run examples:default:output && npm run examples:dynamicDates:output",
     "examples:default": "node examples/default.js",
@@ -25,7 +25,6 @@
   "devDependencies": {
     "dotenv": "^16.0.0",
     "luxon": "^2.3.1",
-    "mocha": "^9.2.2",
     "nyc": "^15.1.0",
     "standard": "^16.0.4"
   },

--- a/templates/package.json
+++ b/templates/package.json
@@ -7,7 +7,7 @@
     "lint": "standard",
     "lint:fix": "standard --fix",
     "test": "node --test",
-    "coverage": "nyc mocha",
+    "coverage": "nyc node --test",
     "examples": "npm run examples:default && npm run examples:usingCore",
     "examples:output": "npm run examples:default:output && npm run examples:usingCore:output",
     "examples:default": "node examples/default.js",


### PR DESCRIPTION
removes mocha and swaps out into `node --test`, but not super useful because we have basically zero tests