### PR TITLE
fix: correct two errors that lead to malformed output

### DIFF
--- a/core/index.js
+++ b/core/index.js
@@ -25,7 +25,7 @@ async function generate (owner, dates = {}, options = {}) {
   }
 
   // the query we pass to GitHub. This includes both the owner and the time range we want to search.
-  const generatedQuery = `org:${owner} updated:${usableDates.start}..${usableDates.end}`
+  const generatedQuery = `org:"${owner}" updated:${usableDates.start}..${usableDates.end}`
   const data = {
     meta: { // general information that we'll want to use in multiple places
       issues: {

--- a/templates/tools/generateBody.js
+++ b/templates/tools/generateBody.js
@@ -7,8 +7,8 @@ async function generateBody (repos) {
   // cache the headings we've already created so we don't dupe them
   const garbageCache = []
 
-  if (Object.keys(repos) === 0 && repos.constructor === Object) {
-    markdown.concat('No activity!')
+  if (Object.keys(repos).length === 0 && repos.constructor === Object) {
+    markdown = markdown.concat('No activity!')
     return markdown
   }
 


### PR DESCRIPTION
this PR fixes two errors that lead to malformed output. One is that the org name is not currently escaped, meaning that the name _could_ mess up the query. The second is that we were not correctly setting the "no activity" markdown output by reassigning the string concat to the original markdown string. Oops.